### PR TITLE
Get mocha binary from npm bin

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ var _ = require('lodash'),
     streamBuffers = require("stream-buffers"),
     through = require('through'),
     split = require('split'),
-    fs = require('fs');
+    fs = require('fs'),
+    os = require('os');
 
 require('colors');
 
@@ -22,6 +23,11 @@ function newStreamBuffer() {
   return stream;
 }
 
+var getNpmBin = _.memoize(function getNpmBin () {
+  // this only happens once, so sync is fine
+  return proc.execSync('npm bin', {encoding: 'utf8'}).trim();
+});
+
 var SpawnMocha = function (opts) {
   var _this = this;
   opts = opts || {};
@@ -30,8 +36,10 @@ var SpawnMocha = function (opts) {
   });
   var queue = async.queue(function (task, done) {
     // Setup
-    var bin = _.isFunction(opts.bin) ? opts.bin() : opts.bin ||
-      join(__dirname, 'node_modules', '.bin', 'mocha');
+    var bin = _.isFunction(opts.bin)
+      ? opts.bin()
+      : opts.bin
+      || join(getNpmBin(), os.platform === 'win32' ? 'mocha.md' : 'mocha');
     var env = _.isFunction(opts.env) ? opts.env() : opts.env || process.env;
     env = _.clone(env);
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "husky": "^2.0.0",
     "vinyl": "^2.0.0"
   },
+  "peerDependency": {
+    "mocha": "^6.0.0"
+  },
   "engines": {
     "node": ">= 0.9.0"
   },


### PR DESCRIPTION
Since npm added deduplication of modules, if this package and the enclosing package have the same `mocha` version it will only exist in the outer `node_modules`, and so this module will not find it.

Rather than get the local `mocha` bin from this package's `node_modules/.bin` folder, find the npm bin folder in play, and get `mocha` from it. 

To make sure there is a `mocha` there, add a peer dependency for it.